### PR TITLE
Adding null message check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.snomed.languages</groupId>
 	<artifactId>snomed-template-parser</artifactId>
-	<version>1.2.0</version>
+	<version>1.2.0-ALO</version>
 
 	<name>SNOMED CT Template Language Parser</name>
 	<description>A parser for Template Language, a SNOMED CT domain specific language.</description>

--- a/src/main/java/org/snomed/authoringtemplate/domain/logical/AttributeGroup.java
+++ b/src/main/java/org/snomed/authoringtemplate/domain/logical/AttributeGroup.java
@@ -86,6 +86,10 @@ public class AttributeGroup implements HasCardinality {
 	}
 
 	public boolean isGrouped() {
-		return this.groupId.intValue() > 0;
+		if (this.groupId == null) {
+			return false;
+		} else {
+			return this.groupId.intValue() > 0;
+		}
 	}
 }


### PR DESCRIPTION
This null check is required to prevent a null pointer exception on the calling of the isGrouped method.